### PR TITLE
Now reading original file size from buffer size

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = options => through2.obj({
     gifsicle       : true,
     svgo           : true
   }, options)).then(buffer => {
-    let original = fs.statSync(file.path).size;
+    let original = file._contents.length;
     let diff = original - buffer.length;
     let diffPercent = round10(100 * (diff / original), -1);
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = options => through2.obj({
     gifsicle       : true,
     svgo           : true
   }, options)).then(buffer => {
-    let original = file._contents.length;
+    let original = file.contents.length;
     let diff = original - buffer.length;
     let diffPercent = round10(100 * (diff / original), -1);
 


### PR DESCRIPTION
Reads original file size from file buffer length, instead of fs stats. Prevents plugin from failing silently when input is a buffer, and not a file on disk.