### PR TITLE
Support a `quiet` option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const filesize = require('filesize');
 const { round10 } = require('round10');
 const optimize = require('./optimize');
 
+function NOOP(){};
+
 const SUPPORTED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg'];
 
 module.exports = options => through2.obj({
@@ -18,6 +20,7 @@ module.exports = options => through2.obj({
   if (file.isNull()) {
     return callback(null, file);
   }
+  const _log = options && options.quiet ? NOOP : log;
 
   if (file.isStream()) {
     return callback(new Error('gulp-image: Streaming is not supported'));
@@ -26,7 +29,7 @@ module.exports = options => through2.obj({
   const extension = extname(file.path).toLowerCase();
 
   if (!SUPPORTED_EXTENSIONS.includes(extension)) {
-    log('gulp-image: Skipping unsupported image ' + colors.blue(file.relative));
+    _log('gulp-image: Skipping unsupported image ' + colors.blue(file.relative));
     return callback(null, file);
   }
 
@@ -46,14 +49,14 @@ module.exports = options => through2.obj({
     const diffPercent = round10(100 * (diff / before), -1);
 
     if (diff <= 0) {
-      log(
+      _log(
         colors.green('- ') + file.relative + colors.gray(' ->') +
         colors.gray(' Cannot improve upon ') + colors.cyan(filesize(before))
       );
     } else {
       file.contents = buffer;
 
-      log(
+      _log(
         colors.green('✔ ') + file.relative + colors.gray(' ->') +
         colors.gray(' before=') + colors.yellow(filesize(before)) +
         colors.gray(' after=') + colors.cyan(filesize(after)) +

--- a/readme.md
+++ b/readme.md
@@ -51,13 +51,14 @@ gulp.task('image', function () {
       guetzli: false,
       gifsicle: true,
       svgo: true,
-      concurrent: 10
+      concurrent: 10,
+      quiet: true // defaults to false
     }))
     .pipe(gulp.dest('./dest'));
 });
 ```
 
-Set `false` for optimizers which you don't want to apply. And you can set `concurrent` option to limit the max concurrency in execution.
+Set `false` for optimizers which you don't want to apply. And you can set `concurrent` option to limit the max concurrency in execution.  You can also set `quiet` to avoid logging out results for every image processed.
 
 You can configure parameters applied to each optimizers such as following:
 


### PR DESCRIPTION
It's annoying in some cases to have logging output, so it's nice to give the option to turn it off.  The current default behaviour is maintained (logging remains on by default).