### PR TITLE
Added external dependencies instructions for Windows

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ $ npm install --save-dev gulp-image
 
 - `brew install libjpeg libpng` on macOS
 - `apt-get install -y libjpeg libpng` on Ubuntu
+- `npm install -g windows-build-tools` on Windows
 
 ## Usage
 


### PR DESCRIPTION
Installing windows-build-tools will allow lib-png, lib-jpeg, and other native Node modules to be compiled on Windows. Adding this to the README will help Windows users get up and running with gulp-image.